### PR TITLE
add frame advance

### DIFF
--- a/source/Core.cpp
+++ b/source/Core.cpp
@@ -62,6 +62,7 @@ bool      g_bFullSpeed      = false;
 //=================================================
 
 AppMode_e	g_nAppMode = MODE_LOGO;
+bool		g_bFrameAdvance = false;
 
 std::string g_sStartDir;	// NB. AppleWin.exe maybe relative to this! (GH#663)
 std::string g_sProgramDir;	// Directory of where AppleWin executable resides

--- a/source/Core.h
+++ b/source/Core.h
@@ -32,6 +32,7 @@ extern bool       g_bFullSpeed;
 //===========================================
 
 extern AppMode_e g_nAppMode;
+extern bool      g_bFrameAdvance;
 
 extern std::string g_sStartDir;
 extern std::string g_sProgramDir;

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -277,6 +277,12 @@ static void ContinueExecution(void)
 		if (g_nAppMode == MODE_RUNNING || g_nAppMode == MODE_STEPPING)
 			RA_DoAchievementsFrame();
 #endif
+
+		if (g_bFrameAdvance)
+		{
+			g_nAppMode = MODE_PAUSED;
+			g_bFrameAdvance = false;
+		}
 	}
 
 #ifdef LOG_PERF_TIMINGS

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1209,16 +1209,37 @@ LRESULT Win32Frame::WndProc(
 		}
 		else if (wparam == VK_PAUSE)
 		{
+			if (KeybGetShiftStatus() &&
+				(g_nAppMode == MODE_PAUSED || g_nAppMode == MODE_STEPPING))
+			{
+				g_nAppMode = MODE_RUNNING;
+#if USE_RETROACHIEVEMENTS
+				RA_SetPaused(false);
+#endif
+			}
+
 			SetUsingCursor(FALSE);
 			switch (g_nAppMode)
 			{
 				case MODE_RUNNING:
-					g_nAppMode = MODE_PAUSED;
 					SoundCore_SetFade(FADE_OUT);
 					RevealCursor();
-#if USE_RETROACHIEVEMENTS
-                    RA_SetPaused(true);
+
+					if (KeybGetShiftStatus()
+#ifdef USE_RETROACHIEVEMENTS
+						&& !RA_HardcoreModeIsActive()
 #endif
+						)
+					{
+						g_bFrameAdvance = true;
+					}
+					else
+					{
+						g_nAppMode = MODE_PAUSED;
+#if USE_RETROACHIEVEMENTS
+						RA_SetPaused(true);
+#endif
+					}
 					break;
 				case MODE_PAUSED:
 					g_nAppMode = MODE_RUNNING;


### PR DESCRIPTION
Since the keyboard is fully functional for Apple II, I've mapped frame advance to "Shift+Pause". You can hold down Shift and press Pause to advance frames, or press Pause without holding Shift to resume normal functionality.

Pressing "Shift+Pause" in hardcore behaves the same as "Pause" and just opens the overlay.